### PR TITLE
Change to standard base64 encoding, provide support for legacy GCM authorization

### DIFF
--- a/vapid_test.go
+++ b/vapid_test.go
@@ -14,7 +14,7 @@ import (
 func TestVAPID(t *testing.T) {
 	assert := assert.New(t)
 
-	s := getTestSubscription()
+	s := getStandardEncodedTestSubscription()
 	sub := "test@test.com"
 	vapidPrivateKey := "MHcCAQEEIHF7ijDrb8gwj_9o7UuSx9t_oGlPMyOsG9YQLp3qJwLuoAoGCCqGSM49AwEHoUQDQgAEhB-nJdg0d5oOkdTYsKqbbuQ06ZUYkS0H-ELXsShIkpmcIVIO16Sj15YMBouesMbY4xPdepwF4Pj3QfaALRAG5Q"
 

--- a/webpush.go
+++ b/webpush.go
@@ -59,6 +59,9 @@ type Options struct {
 	TTL             int        // Set the TTL on the endpoint POST request
 	Urgency         Urgency    // Set the Urgency header to change a message priority (Optional)
 	VAPIDPrivateKey string     // Used to sign VAPID JWT token
+	// Used for Authorization in older Chromium browsers:
+	// https://web-push-book.gauntface.com/chapter-06/01-non-standards-browsers/#what-is-gcm_sender_id
+	LegacyGCMAuthorization string
 }
 
 // Keys are the base64 encoded values from PushSubscription.getKey()
@@ -177,10 +180,15 @@ func SendNotification(message []byte, s *Subscription, options *Options) (*http.
 		req.Header.Set("Topic", options.Topic)
 	}
 
-	// Set VAPID headers
-	err = vapid(req, s, options)
-	if err != nil {
-		return nil, err
+	if len(options.LegacyGCMAuthorization) > 0 && strings.HasPrefix(s.Endpoint, "https://android.googleapis.com/gcm/send") {
+		// Support older Chromium versions which don't yet support VAPID
+		req.Header.Set("Authorization", fmt.Sprintf("key=%s", options.LegacyGCMAuthorization))
+	} else {
+		// Set VAPID headers
+		err = vapid(req, s, options)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// Send the request
@@ -202,7 +210,7 @@ func SendNotification(message []byte, s *Subscription, options *Options) (*http.
 // decodes a base64 subscription key.
 // if necessary, add "=" padding to the key for URL decode
 func decodeSubscriptionKey(key string) ([]byte, error) {
-	b64 := base64.URLEncoding
+	b64 := base64.StdEncoding
 
 	// "=" padding
 	buf := bytes.NewBufferString(key)

--- a/webpush.go
+++ b/webpush.go
@@ -210,15 +210,17 @@ func SendNotification(message []byte, s *Subscription, options *Options) (*http.
 // decodes a base64 subscription key.
 // if necessary, add "=" padding to the key for URL decode
 func decodeSubscriptionKey(key string) ([]byte, error) {
-	b64 := base64.StdEncoding
-
 	// "=" padding
 	buf := bytes.NewBufferString(key)
 	if rem := len(key) % 4; rem != 0 {
 		buf.WriteString(strings.Repeat("=", 4-rem))
 	}
 
-	return b64.DecodeString(buf.String())
+	bytes, err := base64.StdEncoding.DecodeString(buf.String())
+	if err == nil {
+		return bytes, nil
+	}
+	return base64.URLEncoding.DecodeString(buf.String())
 }
 
 // Returns a key of length "length" given an hkdf function

--- a/webpush_test.go
+++ b/webpush_test.go
@@ -13,7 +13,17 @@ func (*testHTTPClient) Do(*http.Request) (*http.Response, error) {
 	return &http.Response{StatusCode: 201}, nil
 }
 
-func getTestSubscription() *Subscription {
+func getURLEncodedTestSubscription() *Subscription {
+	return &Subscription{
+		Endpoint: "https://updates.push.services.mozilla.com/wpush/v2/gAAAAA",
+		Keys: Keys{
+			P256dh: "BNNL5ZaTfK81qhXOx23-wewhigUeFb632jN6LvRWCFH1ubQr77FE_9qV1FuojuRmHP42zmf34rXgW80OvUVDgTk",
+			Auth:   "zqbxT6JKstKSY9JKibZLSQ",
+		},
+	}
+}
+
+func getStandardEncodedTestSubscription() *Subscription {
 	return &Subscription{
 		Endpoint: "https://updates.push.services.mozilla.com/wpush/v2/gAAAAA",
 		Keys: Keys{
@@ -23,10 +33,26 @@ func getTestSubscription() *Subscription {
 	}
 }
 
-func TestSendNotification(t *testing.T) {
+func TestSendNotificationToURLEncodedSubscription(t *testing.T) {
 	assert := assert.New(t)
 
-	resp, err := SendNotification([]byte("Test"), getTestSubscription(), &Options{
+	resp, err := SendNotification([]byte("Test"), getURLEncodedTestSubscription(), &Options{
+		HTTPClient:      &testHTTPClient{},
+		Subscriber:      "mailto:<EMAIL@EXAMPLE.COM>",
+		Topic:           "test_topic",
+		TTL:             0,
+		Urgency:         "low",
+		VAPIDPrivateKey: "testKey",
+	})
+
+	assert.Nil(err)
+	assert.Equal(201, resp.StatusCode)
+}
+
+func TestSendNotificationToStandardEncodedSubscription(t *testing.T) {
+	assert := assert.New(t)
+
+	resp, err := SendNotification([]byte("Test"), getStandardEncodedTestSubscription(), &Options{
 		HTTPClient:      &testHTTPClient{},
 		Subscriber:      "mailto:<EMAIL@EXAMPLE.COM>",
 		Topic:           "test_topic",

--- a/webpush_test.go
+++ b/webpush_test.go
@@ -17,8 +17,8 @@ func getTestSubscription() *Subscription {
 	return &Subscription{
 		Endpoint: "https://updates.push.services.mozilla.com/wpush/v2/gAAAAA",
 		Keys: Keys{
-			P256dh: "BNNL5ZaTfK81qhXOx23-wewhigUeFb632jN6LvRWCFH1ubQr77FE_9qV1FuojuRmHP42zmf34rXgW80OvUVDgTk",
-			Auth:   "zqbxT6JKstKSY9JKibZLSQ",
+			P256dh: "BNNL5ZaTfK81qhXOx23+wewhigUeFb632jN6LvRWCFH1ubQr77FE/9qV1FuojuRmHP42zmf34rXgW80OvUVDgTk=",
+			Auth:   "zqbxT6JKstKSY9JKibZLSQ==",
 		},
 	}
 }
@@ -35,6 +35,6 @@ func TestSendNotification(t *testing.T) {
 		VAPIDPrivateKey: "testKey",
 	})
 
-	assert.Equal(201, resp.StatusCode)
 	assert.Nil(err)
+	assert.Equal(201, resp.StatusCode)
 }


### PR DESCRIPTION
I have tests for these at a higher level