### PR TITLE
Allow UrlEncoding for vapid key

### DIFF
--- a/vapid.go
+++ b/vapid.go
@@ -59,6 +59,14 @@ func generateVAPIDHeaderKeys(privateKey []byte) (*ecdsa.PublicKey, *ecdsa.Privat
 	}
 }
 
+func decodeVapidKey(key string) ([]byte, error) {
+	bytes, err := base64.URLEncoding.DecodeString(key)
+	if err == nil {
+		return bytes, nil
+	}
+	return base64.RawURLEncoding.DecodeString(key)
+}
+
 // Sign the http.Request with the required VAPID headers
 func vapid(req *http.Request, s *Subscription, options *Options) error {
 	// Create the JWT token
@@ -73,9 +81,7 @@ func vapid(req *http.Request, s *Subscription, options *Options) error {
 		"sub": fmt.Sprintf("mailto:%s", options.Subscriber),
 	})
 
-	// ECDSA
-	b64 := base64.RawURLEncoding
-	decodedVapidPrivateKey, err := b64.DecodeString(options.VAPIDPrivateKey)
+	decodedVapidPrivateKey, err := decodeVapidKey(options.VAPIDPrivateKey)
 	if err != nil {
 		return err
 	}

--- a/vapid_test.go
+++ b/vapid_test.go
@@ -61,12 +61,12 @@ func TestVAPID(t *testing.T) {
 }
 
 func TestDecodeVapidKeyAcceptsURLEncoding(t *testing.T) {
-	_, err := decodeVapidKey("MHcCAQEEIHF7ijDrb8gwj_9o7UuSx9t_oGlPMyOsG9YQLp3qJwLuoAoGCCqGSM49AwEHoUQDQgAEhB-nJdg0d5oOkdTYsKqbbuQ06ZUYkS0H-ELXsShIkpmcIVIO16Sj15YMBouesMbY4xPdepwF4Pj3QfaALRAG5Q")
+	_, err := decodeVapidKey("8Xq5BzDqeP9TqEfjt6ZB4TygtMd1ogwstfbAM3KF1W4=")
 	assert.NoError(t, err)
 }
 
 func TestDecodeVapidKeyAcceptsRawURLEncoding(t *testing.T) {
-	_, err := decodeVapidKey("8Xq5BzDqeP9TqEfjt6ZB4TygtMd1ogwstfbAM3KF1W4=")
+	_, err := decodeVapidKey("MHcCAQEEIHF7ijDrb8gwj_9o7UuSx9t_oGlPMyOsG9YQLp3qJwLuoAoGCCqGSM49AwEHoUQDQgAEhB-nJdg0d5oOkdTYsKqbbuQ06ZUYkS0H-ELXsShIkpmcIVIO16Sj15YMBouesMbY4xPdepwF4Pj3QfaALRAG5Q")
 	assert.NoError(t, err)
 }
 

--- a/vapid_test.go
+++ b/vapid_test.go
@@ -58,7 +58,16 @@ func TestVAPID(t *testing.T) {
 	} else {
 		t.Fatal(err)
 	}
+}
 
+func TestDecodeVapidKeyAcceptsURLEncoding(t *testing.T) {
+	_, err := decodeVapidKey("MHcCAQEEIHF7ijDrb8gwj_9o7UuSx9t_oGlPMyOsG9YQLp3qJwLuoAoGCCqGSM49AwEHoUQDQgAEhB-nJdg0d5oOkdTYsKqbbuQ06ZUYkS0H-ELXsShIkpmcIVIO16Sj15YMBouesMbY4xPdepwF4Pj3QfaALRAG5Q")
+	assert.NoError(t, err)
+}
+
+func TestDecodeVapidKeyAcceptsRawURLEncoding(t *testing.T) {
+	_, err := decodeVapidKey("8Xq5BzDqeP9TqEfjt6ZB4TygtMd1ogwstfbAM3KF1W4=")
+	assert.NoError(t, err)
 }
 
 func TestVAPIDKeys(t *testing.T) {


### PR DESCRIPTION
our ruby library generates the keys with url base64 encoding instead of raw url base64 encoding. go's implementation is not very permissive by default.