### PR TITLE
Fix 403 from chrome when vapid public key is standard base64 encoded …

### DIFF
--- a/vapid.go
+++ b/vapid.go
@@ -98,9 +98,14 @@ func getVAPIDAuthorizationHeader(
 		return "", err
 	}
 
+	decodedVapidPublicKey, err := decodeVapidKey(vapidPublicKey)
+	if err != nil {
+		return "", err
+	}
+
 	return fmt.Sprintf(
 		"vapid t=%s, k=%s",
 		jwtString,
-		vapidPublicKey,
+		base64.RawURLEncoding.EncodeToString(decodedVapidPublicKey),
 	), nil
 }


### PR DESCRIPTION
…(instead of url)

{review: I have a test in web-push-service that red/greens with this change}