### PR TITLE
[CH-NOTIX] Update crypto library to fix vulnerabilities

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/Appboy/webpush-go
 
 require (
 	github.com/golang-jwt/jwt v3.2.2+incompatible
-	golang.org/x/crypto v0.0.0-20190131182504-b8fe1690c613
+	golang.org/x/crypto v0.36.0
 )
 
-go 1.13
+go 1.23.7

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
 github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
 github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
-golang.org/x/crypto v0.0.0-20190131182504-b8fe1690c613 h1:MQ/ZZiDsUapFFiMS+vzwXkCTeEKaum+Do5rINYJDmxc=
-golang.org/x/crypto v0.0.0-20190131182504-b8fe1690c613/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
+golang.org/x/crypto v0.36.0 h1:AnAEvhDddvBdpY+uR+MyHmuZzzNqXSe/GvuDeob5L34=
+golang.org/x/crypto v0.36.0/go.mod h1:Y4J0ReaxCR1IMaabaSMugxJES1EpwhBHhv2bDHklZvc=


### PR DESCRIPTION
web-push-service is currently having a CI problem due to this package being very outdated. I updated the golang here and the crypto library, should potentially resolve security issues.

Honestly, I have no idea how to catch all of the potential issues from this update, I'll try to update web-push-service with this change in Olaf and try to send web pushes to Android Firefox and Desktop Chrome browsers

Before:
```
Nikita.Nikolaenko@BZCADP7V90V2PX webpush-go % govulncheck ./...
=== Symbol Results ===

Vulnerability #1: GO-2025-3447
    Timing sidechannel for P-256 on ppc64le in crypto/internal/nistec
  More info: https://pkg.go.dev/vuln/GO-2025-3447
  Standard library
    Found in: crypto/internal/nistec@go1.23.2
    Fixed in: crypto/internal/nistec@go1.23.6
    Platforms: ppc64le
    Example traces found:
      #1: webpush.go:98:52: webpush.SendNotificationWithContext calls elliptic.GenerateKey, which eventually calls nistec.P256Point.ScalarBaseMult
      #2: webpush.go:111:27: webpush.SendNotificationWithContext calls elliptic.nistCurve[*crypto/internal/nistec.P256Point].ScalarMult[*crypto/internal/nistec.P256Point], which calls nistec.P256Point.ScalarMult
      #3: webpush.go:106:40: webpush.SendNotificationWithContext calls elliptic.Unmarshal, which eventually calls nistec.P256Point.SetBytes

Vulnerability #2: GO-2025-3420
    Sensitive headers incorrectly sent after cross-domain redirect in net/http
  More info: https://pkg.go.dev/vuln/GO-2025-3420
  Standard library
    Found in: net/http@go1.23.2
    Fixed in: net/http@go1.23.5
    Example traces found:
      #1: webpush.go:231:18: webpush.SendNotificationWithContext calls http.Client.Do

Vulnerability #3: GO-2025-3373
    Usage of IPv6 zone IDs can bypass URI name constraints in crypto/x509
  More info: https://pkg.go.dev/vuln/GO-2025-3373
  Standard library
    Found in: crypto/x509@go1.23.2
    Fixed in: crypto/x509@go1.23.5
    Example traces found:
      #1: webpush.go:254:23: webpush.getHKDFKey calls io.ReadFull, which eventually calls x509.Certificate.Verify
      #2: webpush.go:254:23: webpush.getHKDFKey calls io.ReadFull, which eventually calls x509.Certificate.VerifyHostname
      #3: vapid.go:77:20: webpush.getVAPIDAuthorizationHeader calls fmt.Sprintf, which eventually calls x509.HostnameError.Error
      #4: webpush.go:254:23: webpush.getHKDFKey calls io.ReadFull, which eventually calls x509.ParseCertificate

Your code is affected by 3 vulnerabilities from the Go standard library.
```

After:
```
Nikita.Nikolaenko@BZCADP7V90V2PX webpush-go % govulncheck -show verbose ./...
Fetching vulnerabilities from the database...

Checking the code against the vulnerabilities...

The package pattern matched the following root package:
  github.com/Appboy/webpush-go
Govulncheck scanned the following 3 modules and the go1.23.7 standard library:
  github.com/Appboy/webpush-go
  github.com/golang-jwt/jwt@v3.2.2+incompatible
  golang.org/x/crypto@v0.36.0

No vulnerabilities found.

```